### PR TITLE
make inspect() return an event emitter that emits each chunk written

### DIFF
--- a/src/_index_test.js
+++ b/src/_index_test.js
@@ -165,6 +165,16 @@ describe("'asynchronous' inspect", function() {
 		});
 	});
 
+  it("allows output to be captured asynchronously", function() {
+		var inspect = stdout.inspect();
+		var data = [];
+		inspect.on("data", function (string) {
+			data.push(string);
+		});
+		console.log("foo");
+		inspect.restore();
+		assert.deepEqual(data, ["foo\n"], "chunk should be emitted");
+	});
 });
 
 


### PR DESCRIPTION
it allows async test scripts to interact with the output, eg. by writing
to stdin once an expected output is received